### PR TITLE
Use github.token for built-in auth in main-ci

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}
           publish_dir: ./build
           cname: support.n3o.ltd
           user_name: github-actions[bot]


### PR DESCRIPTION
Replaces `secrets.GITHUB_TOKEN` with the identical `${{ github.token }}` for built-in, same-repo Actions auth.

Same auto-generated, repo-scoped token — **no behavior or security change** — but it drops the literal `GITHUB_TOKEN` string. Part of standardizing token naming across n3o: `GH_PAT` for cross-repo / GitHub Packages auth, `github.token` for the built-in same-repo token (the convention already used in the `status` repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)